### PR TITLE
fix: restore visual diff preview triggering

### DIFF
--- a/bin/vim-close-diff.py
+++ b/bin/vim-close-diff.py
@@ -14,7 +14,7 @@ def main():
 
     cwd = os.getcwd()
     claude_dir = os.path.join(cwd, ".claude", "tmp")
-    prefix = os.path.join(claude_dir, "vim-diff")
+    prefix = os.path.join(claude_dir, "claude-vim-diff")
     close_trigger = f"{prefix}-close"
 
     os.makedirs(claude_dir, exist_ok=True)

--- a/bin/vim-preview-diff.py
+++ b/bin/vim-preview-diff.py
@@ -41,7 +41,7 @@ def main():
     claude_dir = os.path.join(cwd, ".claude", "tmp")
     os.makedirs(claude_dir, exist_ok=True)
     
-    prefix = os.path.join(claude_dir, "vim-diff")
+    prefix = os.path.join(claude_dir, "claude-vim-diff")
     orig_file = f"{prefix}-original"
     prop_file = f"{prefix}-proposed"
     trigger_file = f"{prefix}-trigger.json"


### PR DESCRIPTION
This PR fixes a critical regression where the Python hook output filenames didn't match the Vimscript background polling timer expectations, successfully restoring full Diff Preview capabilities.