### PR TITLE
build: auto-bump internal version variables

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -19,5 +19,12 @@ perl -pi -e "s/version-[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?-blue\.svg/versi
 # This replaces any instances of `vX.Y.Z` globally (git branch, tags, headers).
 perl -pi -e "s/v[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?/v${NEW_VERSION}/g" README.md
 
+# Update internal plugin version variable
+perl -pi -e "s/let g:claude_code_version = \"[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?\"/let g:claude_code_version = \"${NEW_VERSION}\"/g" plugin/claude_code.vim
+
+# Update Vader test suite to match the new version
+perl -pi -e "s/g:claude_code_version is set to [0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?/g:claude_code_version is set to ${NEW_VERSION}/g" test/test_dispatch.vader
+perl -pi -e "s/AssertEqual '[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?', g:claude_code_version/AssertEqual '${NEW_VERSION}', g:claude_code_version/g" test/test_dispatch.vader
+
 # Make sure we didn't inadvertently modify anything besides the semver strings!
-echo "Version successfully updated in README.md"
+echo "Version successfully updated across all files"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,7 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main"
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
@@ -13,7 +15,13 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "README.md", "doc/claude_code.txt"],
+        "assets": [
+          "CHANGELOG.md",
+          "README.md",
+          "doc/claude_code.txt",
+          "plugin/claude_code.vim",
+          "test/test_dispatch.vader"
+        ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],


### PR DESCRIPTION
This configures the GitHub release pipeline to natively bump the `g:claude_code_version` variable in `plugin/claude_code.vim` and its associated test files, keeping both documentation and internal code fully synchronized upon release.