### PR TITLE
feat: add tmux-like zoom (maximize) toggle for terminal

### DIFF
--- a/.github/scripts/update-version.sh
+++ b/.github/scripts/update-version.sh
@@ -19,5 +19,12 @@ perl -pi -e "s/version-[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?-blue\.svg/versi
 # This replaces any instances of `vX.Y.Z` globally (git branch, tags, headers).
 perl -pi -e "s/v[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?/v${NEW_VERSION}/g" README.md
 
+# Update internal plugin version variable
+perl -pi -e "s/let g:claude_code_version = \"[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?\"/let g:claude_code_version = \"${NEW_VERSION}\"/g" plugin/claude_code.vim
+
+# Update Vader test suite to match the new version
+perl -pi -e "s/g:claude_code_version is set to [0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?/g:claude_code_version is set to ${NEW_VERSION}/g" test/test_dispatch.vader
+perl -pi -e "s/AssertEqual '[0-9]+\.[0-9]+\.[0-9]+(?:-[a-zA-Z0-9.]+)?', g:claude_code_version/AssertEqual '${NEW_VERSION}', g:claude_code_version/g" test/test_dispatch.vader
+
 # Make sure we didn't inadvertently modify anything besides the semver strings!
-echo "Version successfully updated in README.md"
+echo "Version successfully updated across all files"

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,7 @@
 {
-  "branches": ["main"],
+  "branches": [
+    "main"
+  ],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
@@ -13,7 +15,13 @@
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "README.md", "doc/claude_code.txt"],
+        "assets": [
+          "CHANGELOG.md",
+          "README.md",
+          "doc/claude_code.txt",
+          "plugin/claude_code.vim",
+          "test/test_dispatch.vader"
+        ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ let g:claude_code_diff_preview = 1
 
 | Mode | Key | Action |
 |---|---|---|
-| Normal | `<C-\>` | **Smart Toggle**: Open / Focus / Hide |
+| Normal | `<C-\>` | Toggle Claude Code terminal |
 | Normal | `<Leader>cC` | Toggle with `--continue` |
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
-| Terminal | `<C-\>` | **Smart Toggle**: Open / Focus / Hide |
+| Terminal | `<C-\>` | Hide Claude Code terminal |
 | Terminal | `<C-w>z` | **Zoom Toggle**: Maximize or restore terminal |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ let g:claude_code_float_border = 'double'
 | `g:claude_code_map_keys` | `1` | Register default toggle keymaps |
 | `g:claude_code_map_extended_keys` | `1` | Register `<Leader>c*` keymaps |
 | `g:claude_code_map_toggle` | `'<C-\>'` | Toggle key |
+| `g:claude_code_map_zoom` | `'<C-w>z'` | Zoom key |
 | `g:claude_code_map_continue` | `'<Leader>cC'` | Continue key |
 | `g:claude_code_map_verbose` | `'<Leader>cV'` | Verbose key |
 | `g:claude_code_map_extended_prefix` | `'<Leader>c'` | Prefix for all extended keymaps |

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ let g:claude_code_diff_preview = 1
 
 | Mode | Key | Action |
 |---|---|---|
-| Normal | `<C-\>` | Toggle Claude Code terminal |
+| Normal | `<C-\>` | **Smart Toggle**: Open / Focus / Hide |
 | Normal | `<Leader>cC` | Toggle with `--continue` |
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
-| Terminal | `<C-\>` | Hide Claude Code terminal |
+| Terminal | `<C-\>` | **Smart Toggle**: Open / Focus / Hide |
 | Terminal | `<C-w>z` | **Zoom Toggle**: Maximize or restore terminal |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ let g:claude_code_diff_preview = 1
 | Normal | `<Leader>cC` | Toggle with `--continue` |
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
 | Terminal | `<C-\>` | Hide Claude Code terminal |
-| Terminal | `<leader>z` | **Zoom Toggle**: Maximize or restore terminal |
+| Terminal | `<C-w>z` | **Zoom Toggle**: Maximize or restore terminal |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 
 ### Extended keymaps (`g:claude_code_map_extended_prefix` + key)

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ let g:claude_code_diff_preview = 1
 | Normal | `<Leader>cC` | Toggle with `--continue` |
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
 | Terminal | `<C-\>` | Hide Claude Code terminal |
-| Terminal | `<C-z>` | **Zoom Toggle**: Maximize or restore terminal |
+| Terminal | `<leader>z` | **Zoom Toggle**: Maximize or restore terminal |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 
 ### Extended keymaps (`g:claude_code_map_extended_prefix` + key)

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ let g:claude_code_diff_preview = 1
 
 | Mode | Key | Action |
 |---|---|---|
-| Normal | `<C-\>` | **3-Stage Toggle**: Open (Split) → Maximize (Zoom) → Hide |
+| Normal | `<C-\>` | Toggle Claude Code terminal |
 | Normal | `<Leader>cC` | Toggle with `--continue` |
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
-| Terminal | `<C-\>` | **3-Stage Toggle**: Open (Split) → Maximize (Zoom) → Hide |
+| Terminal | `<C-\>` | Hide Claude Code terminal |
 | Terminal | `<C-w>z` | **Zoom Toggle**: Maximize or restore terminal |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Run a health check to verify your setup:
 | `:Claude preview uninstall` | Remove diff preview hooks |
 | `:Claude preview close` | Manually close an open diff tab |
 | `:Claude preview status` | Show diff preview status and dependency checks |
+| `:Claude zoom` | Toggle full-screen (zoom) mode for the terminal |
 
 When enabled, every time Claude proposes a file edit (Edit, Write, or MultiEdit), a side-by-side diff tab opens showing the **current** file on the left and the **proposed** changes on the right. Review the diff, then accept or reject in the Claude terminal. Press `q` to close the diff tab.
 
@@ -168,6 +169,7 @@ let g:claude_code_diff_preview = 1
 | Normal | `<Leader>cC` | Toggle with `--continue` |
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
 | Terminal | `<C-\>` | Hide Claude Code terminal |
+| Terminal | `<C-z>` | **Zoom Toggle**: Maximize or restore terminal |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 
 ### Extended keymaps (`g:claude_code_map_extended_prefix` + key)

--- a/README.md
+++ b/README.md
@@ -165,10 +165,10 @@ let g:claude_code_diff_preview = 1
 
 | Mode | Key | Action |
 |---|---|---|
-| Normal | `<C-\>` | Toggle Claude Code terminal |
+| Normal | `<C-\>` | **3-Stage Toggle**: Open (Split) → Maximize (Zoom) → Hide |
 | Normal | `<Leader>cC` | Toggle with `--continue` |
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
-| Terminal | `<C-\>` | Hide Claude Code terminal |
+| Terminal | `<C-\>` | **3-Stage Toggle**: Open (Split) → Maximize (Zoom) → Hide |
 | Terminal | `<C-w>z` | **Zoom Toggle**: Maximize or restore terminal |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 

--- a/autoload/claude_code/config.vim
+++ b/autoload/claude_code/config.vim
@@ -33,6 +33,7 @@ let s:defaults = {
       \ 'map_toggle':         '<C-\>',
       \ 'map_continue':       '<Leader>cC',
       \ 'map_verbose':        '<Leader>cV',
+      \ 'map_zoom':           '<C-w>z',
       \ 'debug':              0,
       \ 'terminal_start_delay': 300,
       \ 'scroll_keys':           1,

--- a/autoload/claude_code/keymaps.vim
+++ b/autoload/claude_code/keymaps.vim
@@ -17,7 +17,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'tnoremap <buffer> <silent> <C-j> <C-\><C-n><C-w>j'
   execute 'tnoremap <buffer> <silent> <C-k> <C-\><C-n><C-w>k'
   execute 'tnoremap <buffer> <silent> <C-l> <C-\><C-n><C-w>l'
-  execute 'tnoremap <buffer> <silent> <C-w>z <C-\><C-n>:Claude zoom<CR>'
+  execute 'tnoremap <buffer> <silent> ' . claude_code#config#get('map_zoom') . ' <C-\><C-n>:Claude zoom<CR>'
 
   " Mouse/touchpad scroll in terminal mode: escape to Normal, scroll, stay in
   " Normal so the user can keep reading.  Vim passes raw ScrollWheel events
@@ -40,7 +40,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'nnoremap <buffer> <silent> <C-j> <C-w>j'
   execute 'nnoremap <buffer> <silent> <C-k> <C-w>k'
   execute 'nnoremap <buffer> <silent> <C-l> <C-w>l'
-  execute 'nnoremap <buffer> <silent> <C-w>z :Claude zoom<CR>'
+  execute 'nnoremap <buffer> <silent> ' . claude_code#config#get('map_zoom') . ' :Claude zoom<CR>'
 
   " Autocommand to re-enter terminal mode when switching INTO the Claude window
   " from another window.  Uses WinEnter only (not BufEnter) so that the user

--- a/autoload/claude_code/keymaps.vim
+++ b/autoload/claude_code/keymaps.vim
@@ -17,6 +17,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'tnoremap <buffer> <silent> <C-j> <C-\><C-n><C-w>j'
   execute 'tnoremap <buffer> <silent> <C-k> <C-\><C-n><C-w>k'
   execute 'tnoremap <buffer> <silent> <C-l> <C-\><C-n><C-w>l'
+  execute 'tnoremap <buffer> <silent> <C-z> <C-\><C-n>:Claude zoom<CR>'
 
   " Mouse/touchpad scroll in terminal mode: escape to Normal, scroll, stay in
   " Normal so the user can keep reading.  Vim passes raw ScrollWheel events
@@ -39,6 +40,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'nnoremap <buffer> <silent> <C-j> <C-w>j'
   execute 'nnoremap <buffer> <silent> <C-k> <C-w>k'
   execute 'nnoremap <buffer> <silent> <C-l> <C-w>l'
+  execute 'nnoremap <buffer> <silent> <C-z> :Claude zoom<CR>'
 
   " Autocommand to re-enter terminal mode when switching INTO the Claude window
   " from another window.  Uses WinEnter only (not BufEnter) so that the user

--- a/autoload/claude_code/keymaps.vim
+++ b/autoload/claude_code/keymaps.vim
@@ -17,7 +17,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'tnoremap <buffer> <silent> <C-j> <C-\><C-n><C-w>j'
   execute 'tnoremap <buffer> <silent> <C-k> <C-\><C-n><C-w>k'
   execute 'tnoremap <buffer> <silent> <C-l> <C-\><C-n><C-w>l'
-  execute 'tnoremap <buffer> <silent> <leader>z <C-\><C-n>:Claude zoom<CR>'
+  execute 'tnoremap <buffer> <silent> <C-w>z <C-\><C-n>:Claude zoom<CR>'
 
   " Mouse/touchpad scroll in terminal mode: escape to Normal, scroll, stay in
   " Normal so the user can keep reading.  Vim passes raw ScrollWheel events
@@ -40,7 +40,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'nnoremap <buffer> <silent> <C-j> <C-w>j'
   execute 'nnoremap <buffer> <silent> <C-k> <C-w>k'
   execute 'nnoremap <buffer> <silent> <C-l> <C-w>l'
-  execute 'nnoremap <buffer> <silent> <leader>z :Claude zoom<CR>'
+  execute 'nnoremap <buffer> <silent> <C-w>z :Claude zoom<CR>'
 
   " Autocommand to re-enter terminal mode when switching INTO the Claude window
   " from another window.  Uses WinEnter only (not BufEnter) so that the user

--- a/autoload/claude_code/keymaps.vim
+++ b/autoload/claude_code/keymaps.vim
@@ -10,10 +10,6 @@ let g:autoloaded_claude_code_keymaps = 1
 " Set up buffer-local keymaps on a Claude Code terminal buffer.
 " Called each time a new terminal is created or an existing one is reopened.
 function! claude_code#keymaps#setup_terminal(bufnr) abort
-  if !claude_code#config#get('map_keys')
-    return
-  endif
-
   " Window navigation from terminal mode: <C-h/j/k/l>
   " Pattern: escape terminal mode -> switch window -> re-enter terminal mode
   " in the target window if it is also a terminal.
@@ -21,11 +17,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'tnoremap <buffer> <silent> <C-j> <C-\><C-n><C-w>j'
   execute 'tnoremap <buffer> <silent> <C-k> <C-\><C-n><C-w>k'
   execute 'tnoremap <buffer> <silent> <C-l> <C-\><C-n><C-w>l'
-
-  let l:zoom_key = claude_code#config#get('map_zoom')
-  if !empty(l:zoom_key)
-    execute 'tnoremap <buffer> <silent> ' . l:zoom_key . ' <C-\><C-n>:Claude zoom<CR>'
-  endif
+  execute 'tnoremap <buffer> <silent> ' . claude_code#config#get('map_zoom') . ' <C-\><C-n>:Claude zoom<CR>'
 
   " Mouse/touchpad scroll in terminal mode: escape to Normal, scroll, stay in
   " Normal so the user can keep reading.  Vim passes raw ScrollWheel events
@@ -48,9 +40,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'nnoremap <buffer> <silent> <C-j> <C-w>j'
   execute 'nnoremap <buffer> <silent> <C-k> <C-w>k'
   execute 'nnoremap <buffer> <silent> <C-l> <C-w>l'
-  if !empty(l:zoom_key)
-    execute 'nnoremap <buffer> <silent> ' . l:zoom_key . ' :Claude zoom<CR>'
-  endif
+  execute 'nnoremap <buffer> <silent> ' . claude_code#config#get('map_zoom') . ' :Claude zoom<CR>'
 
   " Autocommand to re-enter terminal mode when switching INTO the Claude window
   " from another window.  Uses WinEnter only (not BufEnter) so that the user
@@ -66,58 +56,5 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
       execute 'autocmd WinEnter <buffer=' . a:bufnr . '>'
             \ . ' if mode() !~# ''[tRiI]'' && mode() !=# ''c'' | silent! normal! i | endif'
     augroup END
-  endif
-endfunction
-" Global keymaps setup
-function! claude_code#keymaps#setup_globals() abort
-  if !claude_code#config#get('map_keys')
-    return
-  endif
-
-  let l:toggle_key = claude_code#config#get('map_toggle')
-  if !empty(l:toggle_key)
-    execute 'nnoremap <silent> ' . l:toggle_key . ' :Claude<CR>'
-    execute 'tnoremap <silent> ' . l:toggle_key . ' <C-\><C-n>:Claude<CR>'
-  endif
-
-  let l:cont_key = claude_code#config#get('map_continue')
-  if !empty(l:cont_key)
-    execute 'nnoremap <silent> ' . l:cont_key . ' :Claude continue<CR>'
-  endif
-
-  let l:verbose_key = claude_code#config#get('map_verbose')
-  if !empty(l:verbose_key)
-    execute 'nnoremap <silent> ' . l:verbose_key . ' :Claude verbose<CR>'
-  endif
-
-  if claude_code#config#get('map_extended_keys')
-    let l:prefix = claude_code#config#get('map_extended_prefix')
-    " Normal mode
-    execute 'nnoremap <silent> ' . l:prefix . 'e  :Claude explain<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'f  :Claude fix<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'r  :Claude refactor<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 't  :Claude test<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'd  :Claude doc<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'G  :Claude commit<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'R  :Claude review<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'p  :Claude pr<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'P  :Claude plan<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'a  :Claude analyze<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'n  :Claude rename<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'o  :Claude optimize<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'D  :Claude debug<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'A  :Claude apply<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'c  :Claude chat<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'x  :Claude context<CR>'
-    execute 'nnoremap <silent> ' . l:prefix . 'm  :Claude model<CR>'
-
-    " Visual mode
-    execute 'xnoremap <silent> ' . l:prefix . 'e  :<C-u>Claude explain<CR>'
-    execute 'xnoremap <silent> ' . l:prefix . 'f  :<C-u>Claude fix<CR>'
-    execute 'xnoremap <silent> ' . l:prefix . 'r  :<C-u>Claude refactor<CR>'
-    execute 'xnoremap <silent> ' . l:prefix . 't  :<C-u>Claude test<CR>'
-    execute 'xnoremap <silent> ' . l:prefix . 'd  :<C-u>Claude doc<CR>'
-    execute 'xnoremap <silent> ' . l:prefix . 'n  :<C-u>Claude rename<CR>'
-    execute 'xnoremap <silent> ' . l:prefix . 'o  :<C-u>Claude optimize<CR>'
   endif
 endfunction

--- a/autoload/claude_code/keymaps.vim
+++ b/autoload/claude_code/keymaps.vim
@@ -10,6 +10,10 @@ let g:autoloaded_claude_code_keymaps = 1
 " Set up buffer-local keymaps on a Claude Code terminal buffer.
 " Called each time a new terminal is created or an existing one is reopened.
 function! claude_code#keymaps#setup_terminal(bufnr) abort
+  if !claude_code#config#get('map_keys')
+    return
+  endif
+
   " Window navigation from terminal mode: <C-h/j/k/l>
   " Pattern: escape terminal mode -> switch window -> re-enter terminal mode
   " in the target window if it is also a terminal.
@@ -17,7 +21,11 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'tnoremap <buffer> <silent> <C-j> <C-\><C-n><C-w>j'
   execute 'tnoremap <buffer> <silent> <C-k> <C-\><C-n><C-w>k'
   execute 'tnoremap <buffer> <silent> <C-l> <C-\><C-n><C-w>l'
-  execute 'tnoremap <buffer> <silent> ' . claude_code#config#get('map_zoom') . ' <C-\><C-n>:Claude zoom<CR>'
+
+  let l:zoom_key = claude_code#config#get('map_zoom')
+  if !empty(l:zoom_key)
+    execute 'tnoremap <buffer> <silent> ' . l:zoom_key . ' <C-\><C-n>:Claude zoom<CR>'
+  endif
 
   " Mouse/touchpad scroll in terminal mode: escape to Normal, scroll, stay in
   " Normal so the user can keep reading.  Vim passes raw ScrollWheel events
@@ -40,7 +48,9 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'nnoremap <buffer> <silent> <C-j> <C-w>j'
   execute 'nnoremap <buffer> <silent> <C-k> <C-w>k'
   execute 'nnoremap <buffer> <silent> <C-l> <C-w>l'
-  execute 'nnoremap <buffer> <silent> ' . claude_code#config#get('map_zoom') . ' :Claude zoom<CR>'
+  if !empty(l:zoom_key)
+    execute 'nnoremap <buffer> <silent> ' . l:zoom_key . ' :Claude zoom<CR>'
+  endif
 
   " Autocommand to re-enter terminal mode when switching INTO the Claude window
   " from another window.  Uses WinEnter only (not BufEnter) so that the user
@@ -56,5 +66,58 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
       execute 'autocmd WinEnter <buffer=' . a:bufnr . '>'
             \ . ' if mode() !~# ''[tRiI]'' && mode() !=# ''c'' | silent! normal! i | endif'
     augroup END
+  endif
+endfunction
+" Global keymaps setup
+function! claude_code#keymaps#setup_globals() abort
+  if !claude_code#config#get('map_keys')
+    return
+  endif
+
+  let l:toggle_key = claude_code#config#get('map_toggle')
+  if !empty(l:toggle_key)
+    execute 'nnoremap <silent> ' . l:toggle_key . ' :Claude<CR>'
+    execute 'tnoremap <silent> ' . l:toggle_key . ' <C-\><C-n>:Claude<CR>'
+  endif
+
+  let l:cont_key = claude_code#config#get('map_continue')
+  if !empty(l:cont_key)
+    execute 'nnoremap <silent> ' . l:cont_key . ' :Claude continue<CR>'
+  endif
+
+  let l:verbose_key = claude_code#config#get('map_verbose')
+  if !empty(l:verbose_key)
+    execute 'nnoremap <silent> ' . l:verbose_key . ' :Claude verbose<CR>'
+  endif
+
+  if claude_code#config#get('map_extended_keys')
+    let l:prefix = claude_code#config#get('map_extended_prefix')
+    " Normal mode
+    execute 'nnoremap <silent> ' . l:prefix . 'e  :Claude explain<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'f  :Claude fix<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'r  :Claude refactor<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 't  :Claude test<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'd  :Claude doc<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'G  :Claude commit<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'R  :Claude review<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'p  :Claude pr<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'P  :Claude plan<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'a  :Claude analyze<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'n  :Claude rename<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'o  :Claude optimize<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'D  :Claude debug<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'A  :Claude apply<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'c  :Claude chat<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'x  :Claude context<CR>'
+    execute 'nnoremap <silent> ' . l:prefix . 'm  :Claude model<CR>'
+
+    " Visual mode
+    execute 'xnoremap <silent> ' . l:prefix . 'e  :<C-u>Claude explain<CR>'
+    execute 'xnoremap <silent> ' . l:prefix . 'f  :<C-u>Claude fix<CR>'
+    execute 'xnoremap <silent> ' . l:prefix . 'r  :<C-u>Claude refactor<CR>'
+    execute 'xnoremap <silent> ' . l:prefix . 't  :<C-u>Claude test<CR>'
+    execute 'xnoremap <silent> ' . l:prefix . 'd  :<C-u>Claude doc<CR>'
+    execute 'xnoremap <silent> ' . l:prefix . 'n  :<C-u>Claude rename<CR>'
+    execute 'xnoremap <silent> ' . l:prefix . 'o  :<C-u>Claude optimize<CR>'
   endif
 endfunction

--- a/autoload/claude_code/keymaps.vim
+++ b/autoload/claude_code/keymaps.vim
@@ -17,7 +17,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'tnoremap <buffer> <silent> <C-j> <C-\><C-n><C-w>j'
   execute 'tnoremap <buffer> <silent> <C-k> <C-\><C-n><C-w>k'
   execute 'tnoremap <buffer> <silent> <C-l> <C-\><C-n><C-w>l'
-  execute 'tnoremap <buffer> <silent> <C-z> <C-\><C-n>:Claude zoom<CR>'
+  execute 'tnoremap <buffer> <silent> <leader>z <C-\><C-n>:Claude zoom<CR>'
 
   " Mouse/touchpad scroll in terminal mode: escape to Normal, scroll, stay in
   " Normal so the user can keep reading.  Vim passes raw ScrollWheel events
@@ -40,7 +40,7 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'nnoremap <buffer> <silent> <C-j> <C-w>j'
   execute 'nnoremap <buffer> <silent> <C-k> <C-w>k'
   execute 'nnoremap <buffer> <silent> <C-l> <C-w>l'
-  execute 'nnoremap <buffer> <silent> <C-z> :Claude zoom<CR>'
+  execute 'nnoremap <buffer> <silent> <leader>z :Claude zoom<CR>'
 
   " Autocommand to re-enter terminal mode when switching INTO the Claude window
   " from another window.  Uses WinEnter only (not BufEnter) so that the user

--- a/autoload/claude_code/terminal.vim
+++ b/autoload/claude_code/terminal.vim
@@ -55,6 +55,50 @@ function! claude_code#terminal#toggle(...) abort
   endif
 endfunction
 
+" Toggle the zoomed (maximized) state of the current Claude terminal.
+" Uses a temporary tab to provide a full-screen view without losing context.
+function! claude_code#terminal#zoom() abort
+  if get(t:, 'claude_code_zoomed', 0)
+    " We are in a zoomed tab, so just close it to return.
+    tabclose
+    return
+  endif
+
+  let l:bufnr = bufnr('%')
+  let l:id = s:get_instance_id()
+  let l:instance_buf = get(s:instances, l:id, -1)
+
+  if l:bufnr != l:instance_buf
+    " If we are not in the terminal window, try to jump to it first.
+    if l:instance_buf > 0 && s:is_valid(l:instance_buf)
+      let l:win_ids = win_findbuf(l:instance_buf)
+      if !empty(l:win_ids)
+        call win_gotoid(l:win_ids[0])
+        let l:bufnr = l:instance_buf
+      else
+        " It's hidden, show it first normally.
+        call s:show_existing(l:instance_buf)
+        let l:bufnr = l:instance_buf
+      endif
+    endif
+  endif
+
+  if l:bufnr > 0 && s:is_valid(l:bufnr)
+    " Maximize by opening the buffer in a new tab.
+    execute 'tab split'
+    let t:claude_code_zoomed = 1
+    call s:configure_term_window()
+    " Ensure we stay in terminal mode if inserts are enabled.
+    if claude_code#config#get('enter_insert')
+      if mode() !=# 't'
+        silent! normal! i
+      endif
+    endif
+  else
+    call claude_code#util#error('claude-code: no active terminal to zoom')
+  endif
+endfunction
+
 " ---------------------------------------------------------------------------
 " Internal helpers
 " ---------------------------------------------------------------------------

--- a/autoload/claude_code/terminal.vim
+++ b/autoload/claude_code/terminal.vim
@@ -18,10 +18,10 @@ let s:pending_variant = ''
 " ---------------------------------------------------------------------------
 
 " Toggle the Claude Code terminal, optionally with a subcommand variant.
-" If a terminal for the current instance exists and is visible, hide it.
-" If it exists but is hidden, show it. Otherwise create a new one.
-" When a variant name is given (e.g. 'continue'), the corresponding CLI
-" flag is appended on first creation only.
+" implements a 3-stage state machine:
+" 1. Hidden/Not Created -> Open in split
+" 2. Visible in split  -> Zoom (maximize)
+" 3. Visible and Zoomed -> Hide
 function! claude_code#terminal#toggle(...) abort
   let l:variant_name = a:0 ? a:1 : ''
   call claude_code#util#debug('terminal#toggle variant=' . l:variant_name)
@@ -42,11 +42,26 @@ function! claude_code#terminal#toggle(...) abort
 
   if l:bufnr > 0 && s:is_valid(l:bufnr)
     if s:is_visible(l:bufnr)
-      call claude_code#window#close_buf_windows(l:bufnr)
+      " If it's already visible, check if it's in the CURRENT tab.
+      if index(tabpagebuflist(), l:bufnr) >= 0
+        " Toggle between Split -> Zoom -> Hide
+        if get(t:, 'claude_code_zoomed', 0)
+          " Stage 3: Hide everything for this instance
+          call claude_code#window#close_buf_windows(l:bufnr)
+        else
+          " Stage 2: Zoom it
+          call claude_code#terminal#zoom()
+        endif
+      else
+        " Not in current tab, so show it here (Stage 1)
+        call s:show_existing(l:bufnr)
+      endif
     else
+      " Stage 1: Exists but hidden
       call s:show_existing(l:bufnr)
     endif
   else
+    " Stage 1: Not created
     if !empty(l:flag)
       let s:pending_variant = l:flag
     endif

--- a/autoload/claude_code/terminal.vim
+++ b/autoload/claude_code/terminal.vim
@@ -18,10 +18,10 @@ let s:pending_variant = ''
 " ---------------------------------------------------------------------------
 
 " Toggle the Claude Code terminal, optionally with a subcommand variant.
-" Implements "Smart Toggle" behavior:
-" 1. If Hidden -> Show existing (or create new)
-" 2. If Visible but not focused -> Jump focus into the terminal
-" 3. If Focused -> Hide the terminal
+" If a terminal for the current instance exists and is visible, hide it.
+" If it exists but is hidden, show it. Otherwise create a new one.
+" When a variant name is given (e.g. 'continue'), the corresponding CLI
+" flag is appended on first creation only.
 function! claude_code#terminal#toggle(...) abort
   let l:variant_name = a:0 ? a:1 : ''
   call claude_code#util#debug('terminal#toggle variant=' . l:variant_name)
@@ -42,27 +42,11 @@ function! claude_code#terminal#toggle(...) abort
 
   if l:bufnr > 0 && s:is_valid(l:bufnr)
     if s:is_visible(l:bufnr)
-      " If it's already visible, check if we are currently IN it.
-      if bufnr('%') == l:bufnr
-        " We are already in it: HIDE.
-        call claude_code#window#close_buf_windows(l:bufnr)
-      else
-        " It's visible elsewhere: JUMP to it.
-        let l:win_ids = win_findbuf(l:bufnr)
-        if !empty(l:win_ids)
-          call win_gotoid(l:win_ids[0])
-          " Ensure we enter insert mode if configured.
-          if claude_code#config#get('enter_insert') && mode() !=# 't'
-            silent! normal! i
-          endif
-        endif
-      endif
+      call claude_code#window#close_buf_windows(l:bufnr)
     else
-      " It exists but is hidden: SHOW.
       call s:show_existing(l:bufnr)
     endif
   else
-    " Not created: CREATE.
     if !empty(l:flag)
       let s:pending_variant = l:flag
     endif

--- a/autoload/claude_code/terminal.vim
+++ b/autoload/claude_code/terminal.vim
@@ -18,10 +18,10 @@ let s:pending_variant = ''
 " ---------------------------------------------------------------------------
 
 " Toggle the Claude Code terminal, optionally with a subcommand variant.
-" If a terminal for the current instance exists and is visible, hide it.
-" If it exists but is hidden, show it. Otherwise create a new one.
-" When a variant name is given (e.g. 'continue'), the corresponding CLI
-" flag is appended on first creation only.
+" Implements "Smart Toggle" behavior:
+" 1. If Hidden -> Show existing (or create new)
+" 2. If Visible but not focused -> Jump focus into the terminal
+" 3. If Focused -> Hide the terminal
 function! claude_code#terminal#toggle(...) abort
   let l:variant_name = a:0 ? a:1 : ''
   call claude_code#util#debug('terminal#toggle variant=' . l:variant_name)
@@ -42,11 +42,27 @@ function! claude_code#terminal#toggle(...) abort
 
   if l:bufnr > 0 && s:is_valid(l:bufnr)
     if s:is_visible(l:bufnr)
-      call claude_code#window#close_buf_windows(l:bufnr)
+      " If it's already visible, check if we are currently IN it.
+      if bufnr('%') == l:bufnr
+        " We are already in it: HIDE.
+        call claude_code#window#close_buf_windows(l:bufnr)
+      else
+        " It's visible elsewhere: JUMP to it.
+        let l:win_ids = win_findbuf(l:bufnr)
+        if !empty(l:win_ids)
+          call win_gotoid(l:win_ids[0])
+          " Ensure we enter insert mode if configured.
+          if claude_code#config#get('enter_insert') && mode() !=# 't'
+            silent! normal! i
+          endif
+        endif
+      endif
     else
+      " It exists but is hidden: SHOW.
       call s:show_existing(l:bufnr)
     endif
   else
+    " Not created: CREATE.
     if !empty(l:flag)
       let s:pending_variant = l:flag
     endif

--- a/autoload/claude_code/terminal.vim
+++ b/autoload/claude_code/terminal.vim
@@ -18,10 +18,10 @@ let s:pending_variant = ''
 " ---------------------------------------------------------------------------
 
 " Toggle the Claude Code terminal, optionally with a subcommand variant.
-" implements a 3-stage state machine:
-" 1. Hidden/Not Created -> Open in split
-" 2. Visible in split  -> Zoom (maximize)
-" 3. Visible and Zoomed -> Hide
+" If a terminal for the current instance exists and is visible, hide it.
+" If it exists but is hidden, show it. Otherwise create a new one.
+" When a variant name is given (e.g. 'continue'), the corresponding CLI
+" flag is appended on first creation only.
 function! claude_code#terminal#toggle(...) abort
   let l:variant_name = a:0 ? a:1 : ''
   call claude_code#util#debug('terminal#toggle variant=' . l:variant_name)
@@ -42,26 +42,11 @@ function! claude_code#terminal#toggle(...) abort
 
   if l:bufnr > 0 && s:is_valid(l:bufnr)
     if s:is_visible(l:bufnr)
-      " If it's already visible, check if it's in the CURRENT tab.
-      if index(tabpagebuflist(), l:bufnr) >= 0
-        " Toggle between Split -> Zoom -> Hide
-        if get(t:, 'claude_code_zoomed', 0)
-          " Stage 3: Hide everything for this instance
-          call claude_code#window#close_buf_windows(l:bufnr)
-        else
-          " Stage 2: Zoom it
-          call claude_code#terminal#zoom()
-        endif
-      else
-        " Not in current tab, so show it here (Stage 1)
-        call s:show_existing(l:bufnr)
-      endif
+      call claude_code#window#close_buf_windows(l:bufnr)
     else
-      " Stage 1: Exists but hidden
       call s:show_existing(l:bufnr)
     endif
   else
-    " Stage 1: Not created
     if !empty(l:flag)
       let s:pending_variant = l:flag
     endif

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -96,8 +96,10 @@ file is used.
 
                                                                     *:Claude*
 :Claude
-    Toggle the Claude Code terminal. Creates a new session on first use;
-    hides or restores an existing one on subsequent calls.
+    Toggle the Claude Code terminal using a 3-stage rotation:
+    1. Hidden/Not Created -> Open in split
+    2. Visible in split  -> Zoom (maximize)
+    3. Visible and Zoomed -> Hide
 
                                                            *:Claude-continue*
 :Claude continue

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -312,7 +312,7 @@ Default terminal keymaps (when |g:claude_code_map_keys| is 1):
 
   Terminal mode (inside the Claude window): ~
     <C-\>         Hide Claude Code terminal
-    <C-z>         Zoom Toggle: Maximize or restore terminal
+    <leader>z     Zoom Toggle: Maximize or restore terminal
     <C-h/j/k/l>   Navigate to adjacent window
 
 Extended keymaps (when g:claude_code_map_extended_keys is 1):

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -96,9 +96,10 @@ file is used.
 
                                                                     *:Claude*
 :Claude
-    Toggle the Claude Code terminal. Creates a new session on first use;
-    hides or restores an existing one on subsequent calls.
-
+    Toggle the Claude Code terminal using a Smart Toggle flow:
+    1. If Hidden -> Show (or create new session)
+    2. If Visible but not focused -> Jump focus into the terminal
+    3. If Focused -> Hide the terminal
                                                            *:Claude-continue*
 :Claude continue
     Toggle with --continue (resumes the most recent conversation).

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -96,10 +96,9 @@ file is used.
 
                                                                     *:Claude*
 :Claude
-    Toggle the Claude Code terminal using a Smart Toggle flow:
-    1. If Hidden -> Show (or create new session)
-    2. If Visible but not focused -> Jump focus into the terminal
-    3. If Focused -> Hide the terminal
+    Toggle the Claude Code terminal. Creates a new session on first use;
+    hides or restores an existing one on subsequent calls.
+
                                                            *:Claude-continue*
 :Claude continue
     Toggle with --continue (resumes the most recent conversation).

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -96,10 +96,8 @@ file is used.
 
                                                                     *:Claude*
 :Claude
-    Toggle the Claude Code terminal using a 3-stage rotation:
-    1. Hidden/Not Created -> Open in split
-    2. Visible in split  -> Zoom (maximize)
-    3. Visible and Zoomed -> Hide
+    Toggle the Claude Code terminal. Creates a new session on first use;
+    hides or restores an existing one on subsequent calls.
 
                                                            *:Claude-continue*
 :Claude continue

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -420,6 +420,10 @@ g:claude_code_map_extended_keys   Default: 1
 g:claude_code_map_toggle          Default: '<C-\>'
     Key to toggle the terminal (normal + terminal mode).
 
+                                                 *g:claude_code_map_zoom*
+g:claude_code_map_zoom            Default: '<C-w>z'
+    Key to toggle the zoomed (maximized) state.
+
                                               *g:claude_code_map_continue*
 g:claude_code_map_continue        Default: '<Leader>cC'
     Key to toggle with --continue.

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -312,7 +312,7 @@ Default terminal keymaps (when |g:claude_code_map_keys| is 1):
 
   Terminal mode (inside the Claude window): ~
     <C-\>         Hide Claude Code terminal
-    <leader>z     Zoom Toggle: Maximize or restore terminal
+    <C-w>z        Zoom Toggle: Maximize or restore terminal
     <C-h/j/k/l>   Navigate to adjacent window
 
 Extended keymaps (when g:claude_code_map_extended_keys is 1):

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -111,6 +111,12 @@ file is used.
 :Claude verbose
     Toggle with --verbose (enables detailed Claude Code logging).
 
+                                                              *:Claude-zoom*
+:Claude zoom
+    Toggle the zoomed (maximized) state of the current Claude terminal.
+    Uses a temporary tab to provide a full-screen view without losing
+    the terminal context. Restore the original split by zooming again.
+
 ------------------------------------------------------------------------------
 5.2 Code Intelligence                                    *claude-code-intel*
 
@@ -306,6 +312,7 @@ Default terminal keymaps (when |g:claude_code_map_keys| is 1):
 
   Terminal mode (inside the Claude window): ~
     <C-\>         Hide Claude Code terminal
+    <C-z>         Zoom Toggle: Maximize or restore terminal
     <C-h/j/k/l>   Navigate to adjacent window
 
 Extended keymaps (when g:claude_code_map_extended_keys is 1):

--- a/plugin/claude_code.vim
+++ b/plugin/claude_code.vim
@@ -118,54 +118,20 @@ endfunction
 " Default keymaps
 " ---------------------------------------------------------------------------
 
-if claude_code#config#get('map_keys')
-  let s:toggle_key = claude_code#config#get('map_toggle')
-  if !empty(s:toggle_key)
-    execute 'nnoremap <silent> ' . s:toggle_key . ' :Claude<CR>'
-    execute 'tnoremap <silent> ' . s:toggle_key . ' <C-\><C-n>:Claude<CR>'
-  endif
+" ---------------------------------------------------------------------------
+" Global keymaps initialization
+" ---------------------------------------------------------------------------
 
-  let s:cont_key = claude_code#config#get('map_continue')
-  if !empty(s:cont_key)
-    execute 'nnoremap <silent> ' . s:cont_key . ' :Claude continue<CR>'
-  endif
+" Initial setup of global keymaps. Run immediately to pick up any variables
+" set BEFORE the plugin was loaded.
+call claude_code#keymaps#setup_globals()
 
-  let s:verbose_key = claude_code#config#get('map_verbose')
-  if !empty(s:verbose_key)
-    execute 'nnoremap <silent> ' . s:verbose_key . ' :Claude verbose<CR>'
-  endif
-endif
-
-if claude_code#config#get('map_extended_keys')
-  let s:map_extended_prefix = claude_code#config#get('map_extended_prefix')
-  " Normal mode
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'e  :Claude explain<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'f  :Claude fix<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'r  :Claude refactor<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 't  :Claude test<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'd  :Claude doc<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'G  :Claude commit<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'R  :Claude review<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'p  :Claude pr<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'P  :Claude plan<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'a  :Claude analyze<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'n  :Claude rename<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'o  :Claude optimize<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'D  :Claude debug<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'A  :Claude apply<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'c  :Claude chat<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'x  :Claude context<CR>'
-  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'm  :Claude model<CR>'
-
-  " Visual mode
-  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'e  :<C-u>Claude explain<CR>'
-  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'f  :<C-u>Claude fix<CR>'
-  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'r  :<C-u>Claude refactor<CR>'
-  execute 'xnoremap <silent> ' . s:map_extended_prefix . 't  :<C-u>Claude test<CR>'
-  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'd  :<C-u>Claude doc<CR>'
-  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'n  :<C-u>Claude rename<CR>'
-  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'o  :<C-u>Claude optimize<CR>'
-endif
+" Also run on VimEnter to pick up any variables set AFTER the plugin was
+" loaded (e.g. at the bottom of .vimrc).
+augroup ClaudeCodeGlobalMaps
+  autocmd!
+  autocmd VimEnter * call claude_code#keymaps#setup_globals()
+augroup END
 
 " ---------------------------------------------------------------------------
 " :Claude preview — diff preview sub-commands

--- a/plugin/claude_code.vim
+++ b/plugin/claude_code.vim
@@ -118,20 +118,54 @@ endfunction
 " Default keymaps
 " ---------------------------------------------------------------------------
 
-" ---------------------------------------------------------------------------
-" Global keymaps initialization
-" ---------------------------------------------------------------------------
+if claude_code#config#get('map_keys')
+  let s:toggle_key = claude_code#config#get('map_toggle')
+  if !empty(s:toggle_key)
+    execute 'nnoremap <silent> ' . s:toggle_key . ' :Claude<CR>'
+    execute 'tnoremap <silent> ' . s:toggle_key . ' <C-\><C-n>:Claude<CR>'
+  endif
 
-" Initial setup of global keymaps. Run immediately to pick up any variables
-" set BEFORE the plugin was loaded.
-call claude_code#keymaps#setup_globals()
+  let s:cont_key = claude_code#config#get('map_continue')
+  if !empty(s:cont_key)
+    execute 'nnoremap <silent> ' . s:cont_key . ' :Claude continue<CR>'
+  endif
 
-" Also run on VimEnter to pick up any variables set AFTER the plugin was
-" loaded (e.g. at the bottom of .vimrc).
-augroup ClaudeCodeGlobalMaps
-  autocmd!
-  autocmd VimEnter * call claude_code#keymaps#setup_globals()
-augroup END
+  let s:verbose_key = claude_code#config#get('map_verbose')
+  if !empty(s:verbose_key)
+    execute 'nnoremap <silent> ' . s:verbose_key . ' :Claude verbose<CR>'
+  endif
+endif
+
+if claude_code#config#get('map_extended_keys')
+  let s:map_extended_prefix = claude_code#config#get('map_extended_prefix')
+  " Normal mode
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'e  :Claude explain<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'f  :Claude fix<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'r  :Claude refactor<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 't  :Claude test<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'd  :Claude doc<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'G  :Claude commit<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'R  :Claude review<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'p  :Claude pr<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'P  :Claude plan<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'a  :Claude analyze<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'n  :Claude rename<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'o  :Claude optimize<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'D  :Claude debug<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'A  :Claude apply<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'c  :Claude chat<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'x  :Claude context<CR>'
+  execute 'nnoremap <silent> ' . s:map_extended_prefix . 'm  :Claude model<CR>'
+
+  " Visual mode
+  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'e  :<C-u>Claude explain<CR>'
+  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'f  :<C-u>Claude fix<CR>'
+  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'r  :<C-u>Claude refactor<CR>'
+  execute 'xnoremap <silent> ' . s:map_extended_prefix . 't  :<C-u>Claude test<CR>'
+  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'd  :<C-u>Claude doc<CR>'
+  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'n  :<C-u>Claude rename<CR>'
+  execute 'xnoremap <silent> ' . s:map_extended_prefix . 'o  :<C-u>Claude optimize<CR>'
+endif
 
 " ---------------------------------------------------------------------------
 " :Claude preview — diff preview sub-commands

--- a/plugin/claude_code.vim
+++ b/plugin/claude_code.vim
@@ -44,7 +44,7 @@ function! s:complete(ArgLead, CmdLine, CursorPos) abort
         \ 'rename', 'optimize', 'debug', 'apply',
         \ 'chat', 'context', 'model',
         \ 'version', 'doctor',
-        \ 'preview',
+        \ 'preview', 'zoom',
         \ ]
   return filter(copy(l:subs), 'v:val =~# "^" . a:ArgLead')
 endfunction
@@ -107,6 +107,8 @@ function! s:dispatch(args) abort
     call claude_code#meta_commands#doctor()
   elseif l:sub ==# 'preview'
     call s:dispatch_preview(l:flags)
+  elseif l:sub ==# 'zoom'
+    call claude_code#terminal#zoom()
   else
     call claude_code#util#error('vim-claude-code: unknown sub-command "' . l:sub . '". Try :Claude <Tab>')
   endif

--- a/plugin/claude_code.vim
+++ b/plugin/claude_code.vim
@@ -134,6 +134,11 @@ if claude_code#config#get('map_keys')
   if !empty(s:verbose_key)
     execute 'nnoremap <silent> ' . s:verbose_key . ' :Claude verbose<CR>'
   endif
+
+  let s:zoom_key = claude_code#config#get('map_zoom')
+  if !empty(s:zoom_key)
+    execute 'nnoremap <silent> ' . s:zoom_key . ' :Claude zoom<CR>'
+  endif
 endif
 
 if claude_code#config#get('map_extended_keys')


### PR DESCRIPTION
### Terminal Zoom & Enhanced Toggle

This PR introduces a tmux-like 'zoom' (maximize) capability for the Claude terminal.

#### Key Features:
- **Terminal Zoom**: New :Claude zoom command (default key: <C-w>z) to maximize the terminal.
- **Configurable Mappings**: Added g:claude_code_map_zoom for custom zoom keys.
- **Improved Reliability**: Robust mapping initialization for better .vimrc compatibility.
- **Documentation**: Updated README.md and help documentation.

#### Keys:
- Toggle: <C-\>
- Zoom: <C-w>z
