### PR TITLE
Fix UNIX-specific commands to also work on Windows

### DIFF
--- a/autoload/claude_code/git.vim
+++ b/autoload/claude_code/git.vim
@@ -19,13 +19,18 @@ function! claude_code#git#root() abort
     return s:git_root_cache[l:cwd]
   endif
 
-  let l:inside = system('git -C ' . shellescape(l:cwd) . ' rev-parse --is-inside-work-tree 2>/dev/null')
+  let s:output_redirect = ' 2>/dev/null'
+  if has("win32")
+    let s:output_redirect = ' 2>nul'
+  endif
+
+  let l:inside = system('git -C ' . shellescape(l:cwd) . ' rev-parse --is-inside-work-tree' . s:output_redirect)
   if v:shell_error || trim(l:inside) !=# 'true'
     let s:git_root_cache[l:cwd] = ''
     return ''
   endif
 
-  let l:root = trim(system('git -C ' . shellescape(l:cwd) . ' rev-parse --show-toplevel 2>/dev/null'))
+  let l:root = trim(system('git -C ' . shellescape(l:cwd) . ' rev-parse --show-toplevel' . s:output_redirect))
   if v:shell_error
     let s:git_root_cache[l:cwd] = ''
     return ''

--- a/autoload/claude_code/terminal.vim
+++ b/autoload/claude_code/terminal.vim
@@ -134,26 +134,42 @@ function! s:build_command(instance_id) abort
     let l:cmd .= ' ' . s:pending_variant
   endif
 
-  " Wrap in pushd/popd when using a git root different from cwd.
-  if claude_code#config#get('use_git_root') && a:instance_id !=# getcwd() && a:instance_id !=# 'global'
-    let l:cmd = 'pushd ' . shellescape(a:instance_id) . ' && ' . l:cmd . ' ; popd'
-  endif
-
   return l:cmd
+endfunction
+
+" Resolve the working directory for a terminal instance.
+" Returns the instance_id path (normalised for the OS) when it differs from
+" cwd, or an empty string when no directory change is needed.
+function! s:instance_cwd(instance_id) abort
+  if !claude_code#config#get('use_git_root') || a:instance_id ==# 'global'
+    return ''
+  endif
+  " Normalise both sides to forward slashes for a reliable comparison.
+  let l:inst = substitute(a:instance_id, '\\', '/', 'g')
+  let l:cwd  = substitute(getcwd(),      '\\', '/', 'g')
+  if l:inst ==# l:cwd
+    return ''
+  endif
+  " Return an OS-native path so term_start's cwd option works on all platforms.
+  if has('win32')
+    return substitute(a:instance_id, '/', '\\', 'g')
+  endif
+  return a:instance_id
 endfunction
 
 " Create a brand-new Claude Code terminal.
 function! s:create_new(instance_id) abort
   call claude_code#util#debug('terminal: creating new instance for ' . a:instance_id)
   let l:cmd = s:build_command(a:instance_id)
+  let l:cwd = s:instance_cwd(a:instance_id)
   let l:pos = claude_code#window#resolve_position(claude_code#config#get('position'))
 
   if l:pos ==# 'float' && has('popupwin')
-    let l:bufnr = s:create_float_terminal(l:cmd)
+    let l:bufnr = s:create_float_terminal(l:cmd, l:cwd)
   elseif l:pos ==# 'tab'
-    let l:bufnr = s:create_tab_terminal(l:cmd)
+    let l:bufnr = s:create_tab_terminal(l:cmd, l:cwd)
   else
-    let l:bufnr = s:create_split_terminal(l:cmd, l:pos)
+    let l:bufnr = s:create_split_terminal(l:cmd, l:pos, l:cwd)
   endif
 
   if l:bufnr <= 0
@@ -190,7 +206,7 @@ function! s:create_new(instance_id) abort
 endfunction
 
 " Create terminal inside a split window.
-function! s:create_split_terminal(cmd, position) abort
+function! s:create_split_terminal(cmd, position, cwd) abort
   let l:ratio = claude_code#config#get('split_ratio')
   let l:is_vertical = (a:position =~# 'vert')
 
@@ -207,6 +223,10 @@ function! s:create_split_terminal(cmd, position) abort
         \ 'norestore':   1,
         \ }
 
+  if !empty(a:cwd)
+    let l:term_opts['cwd'] = a:cwd
+  endif
+
   " Use term_start with vertical/horizontal option.
   if l:is_vertical
     let l:term_opts['vertical'] = 1
@@ -215,7 +235,7 @@ function! s:create_split_terminal(cmd, position) abort
     let l:term_opts['term_rows'] = l:size
   endif
 
-  let l:bufnr = term_start([&shell, '-c', a:cmd], l:term_opts)
+  let l:bufnr = term_start([&shell, &shellcmdflag, a:cmd], l:term_opts)
 
   " Move window to the correct edge.
   if l:is_vertical
@@ -241,28 +261,38 @@ function! s:create_split_terminal(cmd, position) abort
 endfunction
 
 " Create terminal inside a floating popup.
-function! s:create_float_terminal(cmd) abort
+function! s:create_float_terminal(cmd, cwd) abort
   let l:popup_opts = claude_code#window#build_float_opts(0)
 
-  let l:bufnr = term_start([&shell, '-c', a:cmd], {
+  let l:term_opts = {
         \ 'hidden': 1,
         \ 'term_finish': 'open',
         \ 'term_name':   'claude-code',
         \ 'norestore':   1,
-        \ })
+        \ }
+  if !empty(a:cwd)
+    let l:term_opts['cwd'] = a:cwd
+  endif
+
+  let l:bufnr = term_start([&shell, &shellcmdflag, a:cmd], l:term_opts)
 
   call popup_create(l:bufnr, l:popup_opts)
   return l:bufnr
 endfunction
 
 " Create terminal in a new tab.
-function! s:create_tab_terminal(cmd) abort
-  let l:bufnr = term_start([&shell, '-c', a:cmd], {
+function! s:create_tab_terminal(cmd, cwd) abort
+  let l:term_opts = {
         \ 'term_finish': 'open',
         \ 'term_name':   'claude-code',
         \ 'curwin':      0,
         \ 'norestore':   1,
-        \ })
+        \ }
+  if !empty(a:cwd)
+    let l:term_opts['cwd'] = a:cwd
+  endif
+
+  let l:bufnr = term_start([&shell, &shellcmdflag, a:cmd], l:term_opts)
   " Move to its own tab.
   execute 'tab sbuffer ' . l:bufnr
   " Close the split left behind in the original tab.


### PR DESCRIPTION
This fixes several issues I encountered when attempting to run this plugin on Windows.  I'm running Vim 9.2 on Windows 11 with Powershell.  I'm still new to using the plugin, but so far it seems to work correctly with these changes.

The issues addressed by this change are:

* When starting up GVim with `g:claude_code_diff_preview = 1` would show an error dialog with a failure reading from a temp file in `claude_code#git#root`.  This was due to UNIX-specific error redirection.  Updated to do a platform check and substitute in the correct syntax.
* When pressing <C-\\>, the terminal split would open, but it would be a plain cmd.exe session rather than starting Claude.  This was due to a UNIX-specific command flag.  Updated to use the Vim `&shellcmdflag`.
* After fixing the shell command option, the command would fail to start with the error "The filename, directory name, or volume label syntax is incorrect."  This was due to UNIX-specific syntax in the pushd/popd command line.  Claude fixed this by removing the pushd/popd, normalizing the directory path, and setting the start dir via the term_start options parameter.