### PR TITLE
fix(terminal): prevent mappings from triggering during paste (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ let g:claude_code_map_zoom = '<C-w>z'
 | Normal | `<Leader>cV` | Toggle with `--verbose` |
 | Terminal | `<C-\>` | Hide Claude Code terminal |
 | Terminal | `<C-w>z` | **Zoom Toggle**: Maximize or restore terminal |
+| Terminal | `<C-v>` | **Paste**: Paste system clipboard content |
 | Terminal | `<C-h/j/k/l>` | Navigate to adjacent window |
 
 ### Extended keymaps (`g:claude_code_map_extended_prefix` + key)
@@ -307,6 +308,7 @@ let g:claude_code_float_border = 'double'
 | `g:claude_code_map_extended_keys` | `1` | Register `<Leader>c*` keymaps |
 | `g:claude_code_map_toggle` | `'<C-\>'` | Toggle key |
 | `g:claude_code_map_zoom` | `'<C-w>z'` | Zoom key |
+| `g:claude_code_map_paste` | `'<C-v>'` | Paste key |
 | `g:claude_code_map_continue` | `'<Leader>cC'` | Continue key |
 | `g:claude_code_map_verbose` | `'<Leader>cV'` | Verbose key |
 | `g:claude_code_map_extended_prefix` | `'<Leader>c'` | Prefix for all extended keymaps |
@@ -319,6 +321,7 @@ let g:claude_code_float_border = 'double'
 | `g:claude_code_model` | `''` | Claude model override |
 | `g:claude_code_debug` | `0` | Enable debug logging to message area |
 | `g:claude_code_diff_preview` | `0` | Auto-start diff preview polling on Vim startup |
+| `g:claude_code_bracketed_paste` | `1` | Enable bracketed paste mode support |
 | `g:claude_code_terminal_start_delay` | `300` | Delay (ms) before attaching to Claude terminal |
 
 Buffer-local `b:claude_code_*` overrides take precedence over `g:` variables.

--- a/autoload/claude_code/config.vim
+++ b/autoload/claude_code/config.vim
@@ -34,6 +34,8 @@ let s:defaults = {
       \ 'map_continue':       '<Leader>cC',
       \ 'map_verbose':        '<Leader>cV',
       \ 'map_zoom':           '<C-w>z',
+      \ 'map_paste':          '<C-v>',
+      \ 'bracketed_paste':    1,
       \ 'debug':              0,
       \ 'terminal_start_delay': 300,
       \ 'scroll_keys':           1,

--- a/autoload/claude_code/keymaps.vim
+++ b/autoload/claude_code/keymaps.vim
@@ -19,6 +19,19 @@ function! claude_code#keymaps#setup_terminal(bufnr) abort
   execute 'tnoremap <buffer> <silent> <C-l> <C-\><C-n><C-w>l'
   execute 'tnoremap <buffer> <silent> ' . claude_code#config#get('map_zoom') . ' <C-\><C-n>:Claude zoom<CR>'
 
+  " Paste from system clipboard
+  let l:paste_key = claude_code#config#get('map_paste')
+  if !empty(l:paste_key)
+    execute 'tnoremap <buffer> <silent> ' . l:paste_key . ' <C-\><C-n>:call claude_code#terminal#paste()<CR>'
+  endif
+
+  " Bracketed paste support
+  if claude_code#config#get('bracketed_paste')
+    " This allows Vim to handle the escape sequence sent by terminal emulators
+    " during a paste. We bridge it to our mapping-free paste function.
+    execute 'tnoremap <buffer> <silent> <Esc>[200~ <C-\><C-n>:call claude_code#terminal#paste()<CR>'
+  endif
+
   " Mouse/touchpad scroll in terminal mode: escape to Normal, scroll, stay in
   " Normal so the user can keep reading.  Vim passes raw ScrollWheel events
   " through to the running program when in terminal mode, so we must intercept

--- a/autoload/claude_code/terminal.vim
+++ b/autoload/claude_code/terminal.vim
@@ -142,6 +142,26 @@ function! s:build_command(instance_id) abort
   return l:cmd
 endfunction
 
+" Paste from system clipboard into the terminal buffer.
+" Bypasses terminal mappings using term_sendkeys().
+function! claude_code#terminal#paste() abort
+  let l:bnr = bufnr('%')
+  if getbufvar(l:bnr, '&buftype') !=# 'terminal'
+    return
+  endif
+
+  " Use + register (system clipboard) if available, fallback to * or default.
+  let l:reg = has('clipboard') ? '+' : '"'
+  let l:text = getreg(l:reg)
+  if empty(l:text) && l:reg == '+'
+    let l:text = getreg('*')
+  endif
+
+  if !empty(l:text)
+    call term_sendkeys(l:bnr, l:text)
+  endif
+endfunction
+
 " Create a brand-new Claude Code terminal.
 function! s:create_new(instance_id) abort
   call claude_code#util#debug('terminal: creating new instance for ' . a:instance_id)

--- a/doc/claude_code.txt
+++ b/doc/claude_code.txt
@@ -313,6 +313,7 @@ Default terminal keymaps (when |g:claude_code_map_keys| is 1):
   Terminal mode (inside the Claude window): ~
     <C-\>         Hide Claude Code terminal
     <C-w>z        Zoom Toggle: Maximize or restore terminal
+    <C-v>         Paste: Paste system clipboard content
     <C-h/j/k/l>   Navigate to adjacent window
 
 Extended keymaps (when g:claude_code_map_extended_keys is 1):
@@ -423,6 +424,11 @@ g:claude_code_map_toggle          Default: '<C-\>'
                                                  *g:claude_code_map_zoom*
 g:claude_code_map_zoom            Default: '<C-w>z'
     Key to toggle the zoomed (maximized) state.
+    
+                                                  *g:claude_code_map_paste*
+g:claude_code_map_paste           Default: '<C-v>'
+    Key to paste text from the system clipboard into the terminal.
+    Bypasses terminal mappings using |term_sendkeys()|.
 
                                               *g:claude_code_map_continue*
 g:claude_code_map_continue        Default: '<Leader>cC'
@@ -477,6 +483,11 @@ g:claude_code_diff_preview           Default: 0
     register the hooks. >
         let g:claude_code_diff_preview = 1
 <
+                                           *g:claude_code_bracketed_paste*
+g:claude_code_bracketed_paste        Default: 1
+    Enable bracketed paste mode support. When enabled, terminal emulator
+    pastes (e.g. Ctrl-Shift-V) are captured and sent via |term_sendkeys()|
+    to avoid triggering Vim mappings.
 
                                        *g:claude_code_terminal_start_delay*
 g:claude_code_terminal_start_delay  Default: 300


### PR DESCRIPTION
This PR fixes issue #24 where pasting text into the Claude terminal would trigger Vim mappings (like window navigation).

Changes:
- Added a dedicated mapping-free paste function using `term_sendkeys()`.
- Added support for bracketed paste mode (`<Esc>[200~`) to reliably handle pastes from terminal emulators.
- Added a new `<C-v>` mapping in terminal mode for system clipboard paste.
- Updated documentation and configuration defaults.