### PR TITLE
Account for Windows quirks in preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Most AI coding tools pull you out of your editor — into a browser, a chat wind
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and in `$PATH`
 - Optional: `+popupwin` for floating window mode
 - Optional: `python3` for diff preview (`:Claude preview`)
+  - Note: In Windows, there is a default python3 that redirects to the Windows Store.
+    Run `Claude doctor` to check if you have a valid python3 installation.
+    If you have Python 3, but your installation uses python.exe as the executable, create a python3 symlink.
 
 ## Installation
 

--- a/autoload/claude_code/diff.vim
+++ b/autoload/claude_code/diff.vim
@@ -17,7 +17,7 @@ let s:diff_tab = -1
 let s:diff_bufs = []
 let s:poll_timer = -1
 let s:trigger_dir = ''
-let s:plugin_root = fnamemodify(resolve(expand('<sfile>:p')), ':h:h:h')
+let s:plugin_root = substitute(fnamemodify(resolve(expand('<sfile>:p')), ':h:h:h'), '\\', '/', 'g')
 
 " ---------------------------------------------------------------------------
 " Polling — file-based IPC for hook → Vim communication
@@ -350,7 +350,16 @@ function! claude_code#diff#check_deps() abort
   let l:results = []
 
   if executable('python3')
-    call add(l:results, '[OK]   python3 found')
+    if has('win32') || has('win64')
+      let l:ver = systemlist('python3 --version')[0]
+      if l:ver =~# '^Python 3\.'
+        call add(l:results, '[OK]   python3 found (' . l:ver . ')')
+      else
+        call add(l:results, '[FAIL] python3 found but version is not 3.x (' . l:ver . ')')
+      endif
+    else
+      call add(l:results, '[OK]   python3 found')
+    endif
   else
     call add(l:results, '[FAIL] python3 not found — required for diff preview')
   endif

--- a/autoload/claude_code/diff.vim
+++ b/autoload/claude_code/diff.vim
@@ -17,7 +17,10 @@ let s:diff_tab = -1
 let s:diff_bufs = []
 let s:poll_timer = -1
 let s:trigger_dir = ''
-let s:plugin_root = substitute(fnamemodify(resolve(expand('<sfile>:p')), ':h:h:h'), '\\', '/', 'g')
+let s:plugin_root = fnamemodify(resolve(expand('<sfile>:p')), ':h:h:h')
+if has('win32')
+  let s:plugin_root = substitute(s:plugin_root, '\\', '/', 'g')
+endif
 
 " ---------------------------------------------------------------------------
 " Polling — file-based IPC for hook → Vim communication
@@ -350,7 +353,7 @@ function! claude_code#diff#check_deps() abort
   let l:results = []
 
   if executable('python3')
-    if has('win32') || has('win64')
+    if has('win32')
       let l:ver = systemlist('python3 --version')[0]
       if l:ver =~# '^Python 3\.'
         call add(l:results, '[OK]   python3 found (' . l:ver . ')')


### PR DESCRIPTION
 This fixes two issues I noticed when trying to use the preview feature on Windows.  After accounting for these, the diff preview seems to work nicely on Windows.

1. The `Claude preview install` command generates mixed-path-delimiter paths in the `settings.local.json`.  The base bath of the plugin uses `\` as the path delimiter, but the part within the plugin dir uses `/`.  It looks like Claude is executing commands in Bash, so it doesn't like the backslashes.  This updates the code to normalize the paths to forward slashes, which work on all modern Windows versions.
2. This adds a Python version check and note in the README.md.  On a default Windows 11 installation, the `python3` command does exist, but it's not _actually_ python3.  It's a wrapper script that redirects you to download Python from the Windows store (which is dumb IMO, but that's not the point).  In addition, some Windows Python 3 builds (e.g. the one I install via Ninite) install only a `python.exe`, despite still being a valid Python 3 installation.  This adds explicit version check in `Claude doctor` and a note in the README that you can fix this with a symlink. 