### PR TITLE
Defer start_polling() till VimEnter

### DIFF
--- a/plugin/claude_code.vim
+++ b/plugin/claude_code.vim
@@ -208,7 +208,16 @@ function! s:preview_status() abort
   call claude_code#util#open_scratch('Claude: Preview Status', l:lines)
 endfunction
 
-" Auto-start polling if diff_preview is enabled
+" Auto-start polling if diff_preview is enabled.
+" Wrap in a VimEnter autocmd to allow Vim's setting shellxquote,
+" shellcmdflag, etc. before start_polling().
 if claude_code#config#get('diff_preview')
-  call claude_code#diff#start_polling()
+  if v:vim_did_enter
+    call claude_code#diff#start_polling()
+  else
+    augroup claude_code_diff_preview
+      autocmd!
+      autocmd VimEnter * call claude_code#diff#start_polling()
+    augroup END
+  endif
 endif


### PR DESCRIPTION
Wrap `claude_code#diff#start_polling()` in a `VimEnter` `augroup` to allow Vim to set `shellxquote` before calling `git`.

Patch: failure to execute `claude_code#diff#start_polling()`.

This bug likely requires installing the plugin to the Vim8 `pack` directory.
- `$MYVIMDIR\pack\...\start\vim-claude-code`
- `set g:claude_code_diff_preview = 1`

`s:dispatch_preview` runs before VimEnter. When `g:claude_code_diff_preview = 1`, `s:dispatch_preview` calls `claude_code#diff#start_polling()`, which eventually calls `git`, which fails because `shellxquote` is empty while the vimrc is parsed. Vim sets `shellxquote` before VimEnter so, with the patch, the call to `git` happens (and succeeds) after `shellxquote` is set.
